### PR TITLE
feat: add `keepExtension` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-
-
 # broccoli-graphql-filter
 
 [![Build Status](https://travis-ci.org/csantero/broccoli-graphql-filter.svg?branch=master)](https://travis-ci.org/csantero/broccoli-graphql-filter)
@@ -12,11 +10,18 @@ A [broccoli](https://github.com/joliss/broccoli) filter that converts graphql fi
 npm install --save broccoli-graphql-filter
 ```
 
+## Configuration
+
+- `keepExtension = false`, _optional_ – If `true`, creates files called
+  `my-query.graphql.js` instead of `my-query.js`, so that you can import the
+  files as `./my-query.graphql` instead of `./my-query`.
+
 ## Usage
 
 Given the following .graphql files:
 
 #### my-query.graphql
+
 ```graphql
 #import "./my-fragment.gql"
 
@@ -28,6 +33,7 @@ query myQuery {
 ```
 
 #### my-fragment.graphql
+
 ```graphql
 fragment MyFragment on Foo {
   hello
@@ -37,40 +43,41 @@ fragment MyFragment on Foo {
 the filter will output the following JS:
 
 #### my-query.js
+
 ```js
 const doc = {
-  "kind": "Document",
-  "definitions": [
+  kind: 'Document',
+  definitions: [
     {
-      "kind": "OperationDefinition",
-      "operation": "query",
-      "name": {
-        "kind": "Name",
-        "value": "myQuery"
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: {
+        kind: 'Name',
+        value: 'myQuery'
       },
-      "variableDefinitions": [],
-      "directives": [],
-      "selectionSet": {
-        "kind": "SelectionSet",
-        "selections": [
+      variableDefinitions: [],
+      directives: [],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
           {
-            "kind": "Field",
-            "name": {
-              "kind": "Name",
-              "value": "foo"
+            kind: 'Field',
+            name: {
+              kind: 'Name',
+              value: 'foo'
             },
-            "arguments": [],
-            "directives": [],
-            "selectionSet": {
-              "kind": "SelectionSet",
-              "selections": [
+            arguments: [],
+            directives: [],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
                 {
-                  "kind": "FragmentSpread",
-                  "name": {
-                    "kind": "Name",
-                    "value": "MyFragment"
+                  kind: 'FragmentSpread',
+                  name: {
+                    kind: 'Name',
+                    value: 'MyFragment'
                   },
-                  "directives": []
+                  directives: []
                 }
               ]
             }
@@ -79,58 +86,60 @@ const doc = {
       }
     }
   ],
-  "loc": {
-    "start": 0,
-    "end": 77
+  loc: {
+    start: 0,
+    end: 77
   }
 };
 export default doc;
-import dep0 from "./my-fragment.gql";
+import dep0 from './my-fragment.gql';
 doc.definitions = doc.definitions.concat(dep0.definitions);
 ```
 
 #### my-fragment.js
+
 ```js
 const doc = {
-  "kind": "Document",
-  "definitions": [
+  kind: 'Document',
+  definitions: [
     {
-      "kind": "FragmentDefinition",
-      "name": {
-        "kind": "Name",
-        "value": "MyFragment"
+      kind: 'FragmentDefinition',
+      name: {
+        kind: 'Name',
+        value: 'MyFragment'
       },
-      "typeCondition": {
-        "kind": "NamedType",
-        "name": {
-          "kind": "Name",
-          "value": "Foo"
+      typeCondition: {
+        kind: 'NamedType',
+        name: {
+          kind: 'Name',
+          value: 'Foo'
         }
       },
-      "directives": [],
-      "selectionSet": {
-        "kind": "SelectionSet",
-        "selections": [
+      directives: [],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
           {
-            "kind": "Field",
-            "name": {
-              "kind": "Name",
-              "value": "hello"
+            kind: 'Field',
+            name: {
+              kind: 'Name',
+              value: 'hello'
             },
-            "arguments": [],
-            "directives": []
+            arguments: [],
+            directives: []
           }
         ]
       }
     }
   ],
-  "loc": {
-    "start": 0,
-    "end": 39
+  loc: {
+    start: 0,
+    end: 39
   }
 };
 export default doc;
 ```
 
 ## Acknowledgements
+
 The filter code was extracted from https://github.com/bgentry/ember-apollo-client and was originally contributed by https://github.com/dfreeman.

--- a/package.json
+++ b/package.json
@@ -19,12 +19,9 @@
   ],
   "devDependencies": {
     "broccoli": "^2.0.1",
-    "broccoli-cli": "^1.0.0",
-    "mocha": "^5.2.0",
-    "rimraf": "^2.6.2"
+    "mocha": "^5.2.0"
   },
   "scripts": {
-    "pretest": "broccoli build test/temp",
     "test": "mocha test.js"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,24 +1,64 @@
 'use strict';
 
-var assert = require('assert');
-var fs = require('fs');
-var rimraf = require('rimraf');
+const assert = require('assert');
+const { resolve } = require('path');
+const fs = require('fs').promises;
+const { Builder } = require('broccoli');
+const GraphQLFilter = require('./');
 
-after(function () {
-  rimraf.sync('test/temp/');
-  rimraf.sync('tmp');
+async function build(
+  input = resolve(__dirname, './test/fixture'),
+  options = {},
+  assertions = () => {}
+) {
+  const tree = new GraphQLFilter(input, options);
+
+  const builder = new Builder(tree);
+
+  try {
+    await builder.build();
+    await assertions(builder.outputPath);
+  } finally {
+    await builder.cleanup();
+  }
+}
+
+describe('default options', function() {
+  it('should compile .graphql files', async () =>
+    build(resolve(__dirname, './test/fixture'), {}, async output => {
+      assert.equal(
+        ...(await Promise.all([
+          fs.readFile('test/expected/my-query.js', 'utf8'),
+          fs.readFile(resolve(output, 'my-query.js'), 'utf8')
+        ]))
+      );
+      assert.equal(
+        ...(await Promise.all([
+          fs.readFile('test/expected/my-fragment.js', 'utf8'),
+          fs.readFile(resolve(output, 'my-fragment.js'), 'utf8')
+        ]))
+      );
+    }));
 });
 
-describe('File creation', function() {
-  it('should compile .graphql files', function () {
-    assert.equal(
-      fs.readFileSync('test/expected/my-query.js', 'utf8'),
-      fs.readFileSync('test/temp/my-query.js', 'utf8')
-    );
-
-    assert.equal(
-      fs.readFileSync('test/expected/my-fragment.js', 'utf8'),
-      fs.readFileSync('test/temp/my-fragment.js', 'utf8')
-    );
-  });
+describe('keepExtension = true', function() {
+  it('should compile .graphql files', async () =>
+    build(
+      resolve(__dirname, './test/fixture'),
+      { keepExtension: true },
+      async output => {
+        assert.equal(
+          ...(await Promise.all([
+            fs.readFile('test/expected/my-query.js', 'utf8'),
+            fs.readFile(resolve(output, 'my-query.graphql.js'), 'utf8')
+          ]))
+        );
+        assert.equal(
+          ...(await Promise.all([
+            fs.readFile('test/expected/my-fragment.js', 'utf8'),
+            fs.readFile(resolve(output, 'my-fragment.graphql.js'), 'utf8')
+          ]))
+        );
+      }
+    ));
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -122,13 +122,6 @@ braces@^2.3.1:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-broccoli-cli@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/broccoli-cli/-/broccoli-cli-1.0.0.tgz#69444521a5e631569300fbc196e85e18097b22a4"
-  integrity sha1-aURFIaXmMVaTAPvBluheGAl7IqQ=
-  dependencies:
-    resolve "~0.6.1"
-
 broccoli-kitchen-sink-helpers@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.3.1.tgz#77c7c18194b9664163ec4fcee2793444926e0c06"
@@ -1347,11 +1340,6 @@ resolve@^1.4.0:
   integrity sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==
   dependencies:
     path-parse "^1.0.5"
-
-resolve@~0.6.1:
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-0.6.3.tgz#dd957982e7e736debdf53b58a4dd91754575dd46"
-  integrity sha1-3ZV5gufnNt699TtYpN2RdUV13UY=
 
 ret@~0.1.10:
   version "0.1.15"


### PR DESCRIPTION
Closes #2.

Adds a `keepExtension` option, that defaults to `false`.

If `true`, creates files called `my-query.graphql.js` instead of `my-query.js`, so that you can import the files as `./my-query.graphql` instead of `./my-query`