### PR TITLE
Support .gql extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ gql.disableFragmentWarnings();
 module.exports = class GraphQLFilter extends Filter {
   constructor(inputNode, options) {
     super(inputNode, options);
-    this.extensions = ['graphql'];
+    this.extensions = ['graphql', 'gql'];
     this.targetExtension = 'js';
   }
 

--- a/test.js
+++ b/test.js
@@ -4,13 +4,13 @@ var assert = require('assert');
 var fs = require('fs');
 var rimraf = require('rimraf');
 
-after(function () {
+after(function() {
   rimraf.sync('test/temp/');
   rimraf.sync('tmp');
 });
 
 describe('File creation', function() {
-  it('should compile .graphql files', function () {
+  it('should compile .graphql files', function() {
     assert.equal(
       fs.readFileSync('test/expected/my-query.js', 'utf8'),
       fs.readFileSync('test/temp/my-query.js', 'utf8')
@@ -19,6 +19,18 @@ describe('File creation', function() {
     assert.equal(
       fs.readFileSync('test/expected/my-fragment.js', 'utf8'),
       fs.readFileSync('test/temp/my-fragment.js', 'utf8')
+    );
+  });
+
+  it('should compile .gql files', function() {
+    assert.equal(
+      fs.readFileSync('test/expected/my-query.js', 'utf8'),
+      fs.readFileSync('test/temp/other-query.js', 'utf8')
+    );
+
+    assert.equal(
+      fs.readFileSync('test/expected/my-fragment.js', 'utf8'),
+      fs.readFileSync('test/temp/other-fragment.js', 'utf8')
     );
   });
 });

--- a/test/fixture/other-fragment.gql
+++ b/test/fixture/other-fragment.gql
@@ -1,0 +1,3 @@
+fragment MyFragment on Foo {
+  hello
+}

--- a/test/fixture/other-query.gql
+++ b/test/fixture/other-query.gql
@@ -1,0 +1,7 @@
+#import "./my-fragment.gql"
+
+query myQuery {
+  foo {
+    ...MyFragment
+  }
+}


### PR DESCRIPTION
I would like to support the `.gql` file extension in this addon so that I can differentiate different types of files in my project.  The README already mentions a `.gql` file, but the type must be added to generate the javascript from them.  I've tested this on my local project.