### PR TITLE
Richer import syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,13 @@ To only import specific identifiers, you can write them out separated by commas:
 # import Bar, Baz from 'path/to/bar-baz'
 ```
 
+#### Migrating Import Syntax
+
+Up to `v0.3.2`, `broccoli-graphql-filter` used a coarser-grained import syntax.
+In order to align with the broader ecosystem and enable better static analysis opportunities, we've moved to a subset of [`graphql-import`](https://oss.prisma.io/content/graphql-import/overview)'s syntax.
+
+To keep the semantics of your existing imports while migrating to the new syntax, you can perform project-wide find/replace, replacing all instances of `#import` in your project's GraphQL documents with `# import * from`.
+
 ## Acknowledgements
 
 The filter code was extracted from https://github.com/bgentry/ember-apollo-client and was originally contributed by https://github.com/dfreeman.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Given the following .graphql files:
 #### my-query.graphql
 
 ```graphql
-#import "./my-fragment.gql"
+# import * from "./my-fragment.gql"
 
 query myQuery {
   foo {
@@ -138,6 +138,23 @@ const doc = {
   }
 };
 export default doc;
+```
+
+### Import Syntax
+
+Imports of fragments from other locations are specified using comments in a format compatible with a subset of [`graphql-import`](https://oss.prisma.io/content/graphql-import/overview).
+
+To bring all identifiers in a specific module into scope, you can use `*`:
+
+```graphql
+# import * from 'path/to/module'
+```
+
+To only import specific identifiers, you can write them out separated by commas:
+
+```graphql
+# import Foo from 'path/to/foo'
+# import Bar, Baz from 'path/to/bar-baz'
 ```
 
 ## Acknowledgements

--- a/index.js
+++ b/index.js
@@ -22,13 +22,13 @@ module.exports = class GraphQLFilter extends Filter {
     return `${newPath}.js`;
   }
 
-  processString(source) {
+  processString(source, relativePath) {
     let output = [
       `const doc = ${JSON.stringify(gql([source]), null, 2)};`,
       `export default doc;`
     ];
 
-    extractImports(source).forEach((directive, i) => {
+    extractImports(source, relativePath).forEach((directive, i) => {
       let definitions = `dep${i}.definitions`;
       if (directive.bindings) {
         let matcher = `/^(${directive.bindings.join("|")})$/`;

--- a/lib/extract-imports.js
+++ b/lib/extract-imports.js
@@ -1,9 +1,11 @@
 let importRegex = /^#\s*import\s+(.*?)\s+from\s+(.*)/;
 let legacyImportRegex = /^#import\s+(.*)/;
 
-module.exports = function extractImports(source) {
+module.exports = function extractImports(source, filePath) {
   let lines = source.split("\n");
   let imports = [];
+  let warned = false;
+
   for (let line of lines) {
     let match;
     if (match = importRegex.exec(line)) {
@@ -17,8 +19,16 @@ module.exports = function extractImports(source) {
       }
     } else if (match = legacyImportRegex.exec(line)) {
       imports.push({ source: match[1] });
+      if (!warned) {
+        warned = true;
+        console.warn(
+          `[DEPRECATION] Legacy import syntax found in ${filePath}. ` +
+          'See https://git.io/fjym5 for migration details.'
+        );
+      }
     }
   }
+
   return imports;
 }
 

--- a/lib/extract-imports.js
+++ b/lib/extract-imports.js
@@ -1,0 +1,35 @@
+let importRegex = /^#\s*import\s+(.*?)\s+from\s+(.*)/;
+let legacyImportRegex = /^#import\s+(.*)/;
+
+module.exports = function extractImports(source) {
+  let lines = source.split("\n");
+  let imports = [];
+  for (let line of lines) {
+    let match;
+    if (match = importRegex.exec(line)) {
+      let source = match[2];
+      let bindings = match[1].split(/\s*,\s*/);
+      if (bindings.length === 1 && bindings[0] === "*") {
+        imports.push({ source });
+      } else {
+        validateBindings(bindings);
+        imports.push({ source, bindings });
+      }
+    } else if (match = legacyImportRegex.exec(line)) {
+      imports.push({ source: match[1] });
+    }
+  }
+  return imports;
+}
+
+function validateBindings(bindings) {
+  for (let binding of bindings) {
+    if (binding === '*') {
+      throw new Error("A '*' import must be the only binding");
+    }
+
+    if (!/^[a-z_][a-z0-9_]*$/i.test(binding)) {
+      throw new Error(`Invalid import identifier: ${binding}`);
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   ],
   "devDependencies": {
     "broccoli": "^2.0.1",
+    "common-tags": "^1.8.0",
     "mocha": "^5.2.0"
   },
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -53,7 +53,7 @@ describe("Unit | extractImports", function() {
       # import * from "./foo"
     `;
 
-    assert.deepEqual(extractImports(source), [
+    assert.deepEqual(extractImports(source, 'test.gql'), [
       { source: `"./foo"` }
     ]);
   });
@@ -63,7 +63,7 @@ describe("Unit | extractImports", function() {
       # import Foo, Bar from "./baz"
     `;
 
-    assert.deepEqual(extractImports(source), [
+    assert.deepEqual(extractImports(source, 'test.gql'), [
       { source: `"./baz"`, bindings: ["Foo", "Bar"] }
     ]);
   });
@@ -73,7 +73,7 @@ describe("Unit | extractImports", function() {
       #import "./foo"
     `;
 
-    assert.deepEqual(extractImports(source), [
+    assert.deepEqual(extractImports(source, 'test.gql'), [
       { source: `"./foo"` }
     ]);
   });
@@ -84,7 +84,7 @@ describe("Unit | extractImports", function() {
       # import Bar from "baz"
     `;
 
-    assert.deepEqual(extractImports(source), [
+    assert.deepEqual(extractImports(source, 'test.gql'), [
       { source: `"./foo"` },
       { source: `"baz"`, bindings: ["Bar"] }
     ]);
@@ -96,7 +96,7 @@ describe("Unit | extractImports", function() {
     `;
 
     assert.throws(
-      () => extractImports(source),
+      () => extractImports(source, 'test.gql'),
       new Error("A '*' import must be the only binding")
     );
   });
@@ -107,7 +107,7 @@ describe("Unit | extractImports", function() {
     `;
 
     assert.throws(
-      () => extractImports(source),
+      () => extractImports(source, 'test.gql'),
       new Error("Invalid import identifier: foo-bar")
     );
   });

--- a/test/fixtures/extension-graphql/expected/my-query.js
+++ b/test/fixtures/extension-graphql/expected/my-query.js
@@ -41,7 +41,7 @@ const doc = {
   ],
   "loc": {
     "start": 0,
-    "end": 73
+    "end": 81
   }
 };
 export default doc;

--- a/test/fixtures/extension-graphql/input/my-query.graphql
+++ b/test/fixtures/extension-graphql/input/my-query.graphql
@@ -1,4 +1,4 @@
-#import "./my-fragment"
+# import * from "./my-fragment"
 
 query MyQuery {
   foo {

--- a/test/fixtures/import-legacy/expected/my-fragment.js
+++ b/test/fixtures/import-legacy/expected/my-fragment.js
@@ -1,0 +1,39 @@
+const doc = {
+  "kind": "Document",
+  "definitions": [
+    {
+      "kind": "FragmentDefinition",
+      "name": {
+        "kind": "Name",
+        "value": "MyFragment"
+      },
+      "typeCondition": {
+        "kind": "NamedType",
+        "name": {
+          "kind": "Name",
+          "value": "Foo"
+        }
+      },
+      "directives": [],
+      "selectionSet": {
+        "kind": "SelectionSet",
+        "selections": [
+          {
+            "kind": "Field",
+            "name": {
+              "kind": "Name",
+              "value": "hello"
+            },
+            "arguments": [],
+            "directives": []
+          }
+        ]
+      }
+    }
+  ],
+  "loc": {
+    "start": 0,
+    "end": 39
+  }
+};
+export default doc;

--- a/test/fixtures/import-legacy/expected/my-query.js
+++ b/test/fixtures/import-legacy/expected/my-query.js
@@ -41,7 +41,7 @@ const doc = {
   ],
   "loc": {
     "start": 0,
-    "end": 81
+    "end": 73
   }
 };
 export default doc;

--- a/test/fixtures/import-legacy/input/my-fragment.graphql
+++ b/test/fixtures/import-legacy/input/my-fragment.graphql
@@ -1,0 +1,3 @@
+fragment MyFragment on Foo {
+  hello
+}

--- a/test/fixtures/import-legacy/input/my-query.graphql
+++ b/test/fixtures/import-legacy/input/my-query.graphql
@@ -1,4 +1,4 @@
-# import * from "./my-fragment"
+#import "./my-fragment"
 
 query MyQuery {
   foo {

--- a/test/fixtures/import-named/expected/fragments.js
+++ b/test/fixtures/import-named/expected/fragments.js
@@ -1,0 +1,97 @@
+const doc = {
+  "kind": "Document",
+  "definitions": [
+    {
+      "kind": "FragmentDefinition",
+      "name": {
+        "kind": "Name",
+        "value": "FragmentA"
+      },
+      "typeCondition": {
+        "kind": "NamedType",
+        "name": {
+          "kind": "Name",
+          "value": "Foo"
+        }
+      },
+      "directives": [],
+      "selectionSet": {
+        "kind": "SelectionSet",
+        "selections": [
+          {
+            "kind": "Field",
+            "name": {
+              "kind": "Name",
+              "value": "hello"
+            },
+            "arguments": [],
+            "directives": []
+          }
+        ]
+      }
+    },
+    {
+      "kind": "FragmentDefinition",
+      "name": {
+        "kind": "Name",
+        "value": "FragmentB"
+      },
+      "typeCondition": {
+        "kind": "NamedType",
+        "name": {
+          "kind": "Name",
+          "value": "Foo"
+        }
+      },
+      "directives": [],
+      "selectionSet": {
+        "kind": "SelectionSet",
+        "selections": [
+          {
+            "kind": "Field",
+            "name": {
+              "kind": "Name",
+              "value": "goodbye"
+            },
+            "arguments": [],
+            "directives": []
+          }
+        ]
+      }
+    },
+    {
+      "kind": "FragmentDefinition",
+      "name": {
+        "kind": "Name",
+        "value": "FragmentC"
+      },
+      "typeCondition": {
+        "kind": "NamedType",
+        "name": {
+          "kind": "Name",
+          "value": "Foo"
+        }
+      },
+      "directives": [],
+      "selectionSet": {
+        "kind": "SelectionSet",
+        "selections": [
+          {
+            "kind": "Field",
+            "name": {
+              "kind": "Name",
+              "value": "what"
+            },
+            "arguments": [],
+            "directives": []
+          }
+        ]
+      }
+    }
+  ],
+  "loc": {
+    "start": 0,
+    "end": 117
+  }
+};
+export default doc;

--- a/test/fixtures/import-named/expected/my-query.js
+++ b/test/fixtures/import-named/expected/my-query.js
@@ -28,7 +28,15 @@ const doc = {
                   "kind": "FragmentSpread",
                   "name": {
                     "kind": "Name",
-                    "value": "MyFragment"
+                    "value": "FragmentA"
+                  },
+                  "directives": []
+                },
+                {
+                  "kind": "FragmentSpread",
+                  "name": {
+                    "kind": "Name",
+                    "value": "FragmentC"
                   },
                   "directives": []
                 }
@@ -41,9 +49,9 @@ const doc = {
   ],
   "loc": {
     "start": 0,
-    "end": 81
+    "end": 114
   }
 };
 export default doc;
-import dep0 from "./my-fragment";
-doc.definitions = doc.definitions.concat(dep0.definitions);
+import dep0 from "./fragments";
+doc.definitions = doc.definitions.concat(dep0.definitions.filter(def => /^(FragmentA|FragmentC)$/.test(def.name.value)));

--- a/test/fixtures/import-named/input/fragments.graphql
+++ b/test/fixtures/import-named/input/fragments.graphql
@@ -1,0 +1,11 @@
+fragment FragmentA on Foo {
+  hello
+}
+
+fragment FragmentB on Foo {
+  goodbye
+}
+
+fragment FragmentC on Foo {
+  what
+}

--- a/test/fixtures/import-named/input/my-query.graphql
+++ b/test/fixtures/import-named/input/my-query.graphql
@@ -1,0 +1,8 @@
+# import FragmentA, FragmentC from "./fragments"
+
+query MyQuery {
+  foo {
+    ...FragmentA
+    ...FragmentC
+  }
+}

--- a/test/fixtures/option-keep-extension/expected/my-query.graphql.js
+++ b/test/fixtures/option-keep-extension/expected/my-query.graphql.js
@@ -41,7 +41,7 @@ const doc = {
   ],
   "loc": {
     "start": 0,
-    "end": 81
+    "end": 89
   }
 };
 export default doc;

--- a/test/fixtures/option-keep-extension/input/my-query.graphql
+++ b/test/fixtures/option-keep-extension/input/my-query.graphql
@@ -1,4 +1,4 @@
-#import "./my-fragment.graphql"
+# import * from "./my-fragment.graphql"
 
 query MyQuery {
   foo {

--- a/yarn.lock
+++ b/yarn.lock
@@ -260,6 +260,11 @@ commander@~2.17.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
   integrity sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
 
+common-tags@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.0.tgz#8e3153e542d4a39e9b10554434afaaf98956a937"
+  integrity sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==
+
 component-emitter@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"


### PR DESCRIPTION
This PR (built on top of the diff for #8) introduces support for `graphql-import`-style import directives, as outlined in #3. While there's still no official spec for modularizing GraphQL schemas and operations across files, the `graphql-import` package gets over half a million downloads a week, so seems like the likeliest thing we should attempt syntactic compatibility with for the time being.

A couple thoughts/questions:
 - Should we explicitly deprecate the old syntax? Like-for-like migration should be pretty straightforward: find/replace `#import` ➡️ `# import * from` in all `.graphql` files in a given codebase.
 - ~This doesn't support renaming identifiers as described in #1 (and `graphql-import` doesn't support that at all), but it at least opens the door to it if that's something folks decide is worth investing in down the line.~ I think I was misremembering the heart of that issue. The way this actually stands, if you want to import and use `Foo`, and it references `Bar`, you'd have to `# import Foo, Bar from ...` in order for that to work. That _does_ solve #1, but is probably more painful in the general case—maybe that's just when you fall back to `import *` 🤔