### PR TITLE
Add tests for nested fragment invocation

### DIFF
--- a/test/fixtures/import-legacy/expected/my-nested-fragment.js
+++ b/test/fixtures/import-legacy/expected/my-nested-fragment.js
@@ -1,0 +1,40 @@
+const doc = {
+  "kind": "Document",
+  "definitions": [
+    {
+      "kind": "FragmentDefinition",
+      "name": {
+        "kind": "Name",
+        "value": "MyNestedFragment"
+      },
+      "typeCondition": {
+        "kind": "NamedType",
+        "name": {
+          "kind": "Name",
+          "value": "Foo"
+        }
+      },
+      "directives": [],
+      "selectionSet": {
+        "kind": "SelectionSet",
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": {
+              "kind": "Name",
+              "value": "MyFragment"
+            },
+            "directives": []
+          }
+        ]
+      }
+    }
+  ],
+  "loc": {
+    "start": 0,
+    "end": 80
+  }
+};
+export default doc;
+import dep0 from "./my-fragment";
+doc.definitions = doc.definitions.concat(dep0.definitions);

--- a/test/fixtures/import-legacy/expected/my-query-with-nested-fragment.js
+++ b/test/fixtures/import-legacy/expected/my-query-with-nested-fragment.js
@@ -1,0 +1,59 @@
+const doc = {
+  "kind": "Document",
+  "definitions": [
+    {
+      "kind": "OperationDefinition",
+      "operation": "query",
+      "name": {
+        "kind": "Name",
+        "value": "MyQuery"
+      },
+      "variableDefinitions": [],
+      "directives": [],
+      "selectionSet": {
+        "kind": "SelectionSet",
+        "selections": [
+          {
+            "kind": "FragmentSpread",
+            "name": {
+              "kind": "Name",
+              "value": "MyFragment"
+            },
+            "directives": []
+          },
+          {
+            "kind": "Field",
+            "name": {
+              "kind": "Name",
+              "value": "foo"
+            },
+            "arguments": [],
+            "directives": [],
+            "selectionSet": {
+              "kind": "SelectionSet",
+              "selections": [
+                {
+                  "kind": "FragmentSpread",
+                  "name": {
+                    "kind": "Name",
+                    "value": "MyNestedFragment"
+                  },
+                  "directives": []
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "loc": {
+    "start": 0,
+    "end": 127
+  }
+};
+export default doc;
+import dep0 from "./my-nested-fragment";
+doc.definitions = doc.definitions.concat(dep0.definitions);
+import dep1 from "./my-fragment";
+doc.definitions = doc.definitions.concat(dep1.definitions);

--- a/test/fixtures/import-legacy/input/my-nested-fragment.graphql
+++ b/test/fixtures/import-legacy/input/my-nested-fragment.graphql
@@ -1,0 +1,5 @@
+#import "./my-fragment"
+
+fragment MyNestedFragment on Foo {
+    ...MyFragment
+}

--- a/test/fixtures/import-legacy/input/my-query-with-nested-fragment.graphql
+++ b/test/fixtures/import-legacy/input/my-query-with-nested-fragment.graphql
@@ -1,0 +1,10 @@
+#import "./my-nested-fragment"
+#import "./my-fragment"
+
+query MyQuery {
+  ...MyFragment
+
+  foo {
+    ...MyNestedFragment
+  }
+}


### PR DESCRIPTION
Hello everyone

This PR is continuing on issues which came up here: https://github.com/ember-graphql/ember-apollo-client/pull/298/files.

Please bare with me and let me know if I got anything wrong, I have 0 experience in graphql internals. 
The story is: If I have a fragment in my query, and some of my nested fragments in that query are using the initial fragment also, the doubly used fragment gets included twice in the final graphql representation, and backend rejects the whole request as incorrect.

In the PR I linked I added a test that shows the issue, and this is PR is my attempt at recreating the issue here. However, I don't know much about graphql internals, but these tests pass, and it looks like the `MyFragment` is only included once in representation of `my-query-with-nested-fragment` ?

So I'm a little bit confused. Where do we go with this issue from here?