### PR TITLE
Allow deferring parsing to runtime for smaller payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ npm install --save broccoli-graphql-filter
   `my-query.graphql.js` instead of `my-query.js`, so that you can import the
   files as `./my-query.graphql` instead of `./my-query`.
 
+- `parseAt = 'build-time'`, _optional_ - Determines when documents are parsed.
+  If set to `'run-time'`, GraphQL documents will be included as tagged template
+  strings using `graphql-tag`. If left blank or set to `'build-time'`, documents
+  will be included in their parsed JSON format, which is typically larger than
+  the source document text, but doesn't require additional work at runtime to parse.
+  Note that `'run-time'` requires that the `graphql-tag` package is available to
+  import in your application.
+
 ## Usage
 
 Given the following .graphql files:

--- a/test/fixtures/option-parse-at-runtime/expected/my-fragment.js
+++ b/test/fixtures/option-parse-at-runtime/expected/my-fragment.js
@@ -1,0 +1,6 @@
+import gql from 'graphql-tag';
+const doc = gql`fragment MyFragment on Foo {
+  hello(input: "say \\"hi\\"")
+}
+`;
+export default doc;

--- a/test/fixtures/option-parse-at-runtime/expected/my-query.js
+++ b/test/fixtures/option-parse-at-runtime/expected/my-query.js
@@ -1,0 +1,12 @@
+import gql from 'graphql-tag';
+const doc = gql`# import * from "./my-fragment.graphql"
+
+query MyQuery {
+  foo {
+    ...MyFragment
+  }
+}
+`;
+export default doc;
+import dep0 from "./my-fragment.graphql";
+doc.definitions = doc.definitions.concat(dep0.definitions);

--- a/test/fixtures/option-parse-at-runtime/input/my-fragment.graphql
+++ b/test/fixtures/option-parse-at-runtime/input/my-fragment.graphql
@@ -1,0 +1,3 @@
+fragment MyFragment on Foo {
+  hello(input: "say \"hi\"")
+}

--- a/test/fixtures/option-parse-at-runtime/input/my-query.graphql
+++ b/test/fixtures/option-parse-at-runtime/input/my-query.graphql
@@ -1,0 +1,7 @@
+# import * from "./my-fragment.graphql"
+
+query MyQuery {
+  foo {
+    ...MyFragment
+  }
+}

--- a/test/fixtures/option-parse-at-runtime/options.json
+++ b/test/fixtures/option-parse-at-runtime/options.json
@@ -1,0 +1,3 @@
+{
+  "parseAt": "run-time"
+}


### PR DESCRIPTION
One thing we've found as our use of GraphQL has grown (particularly when we include schema documents in our build for use with Apollo) is that the JSON representation of document ASTs can often be an order of magnitude larger than their source text.

This PR introduces an option to defer parsing to runtime, emitting a tagged template string using `graphql-tag` rather than the parsed JSON.