### PR TITLE
fix: wrap super.getDestFilePath() in try/catch

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,14 @@ module.exports = class GraphQLFilter extends Filter {
   }
 
   getDestFilePath(relativePath, entry) {
-    const newPath = super.getDestFilePath(relativePath, entry);
+    let newPath;
+    try {
+      newPath = super.getDestFilePath(relativePath, entry);
+    } catch (e) {
+      if (e.code !== 'ENOENT') {
+        throw e;
+      }
+    }
     if (!newPath || this.targetExtension) {
       return newPath;
     }


### PR DESCRIPTION
When `ember serve` is running and a file is deleted, the following error is triggered:
```
ENOENT: no such file or directory, lstat 
```
This is is because broccoli-persistent-filter is [attempting to lstat the path without first checking that it exists](https://github.com/broccolijs/broccoli-persistent-filter/blob/7ba962659f2e6759b8e14e76253d9b83c0d32a96/index.js#L385).
This could be fixed upstream, but broccoli-persistent-filter is now on v3, which is not compatible with the latest broccoli-babel-transpiler.

Upstream PR: https://github.com/broccolijs/broccoli-persistent-filter/pull/207

Edit: I've realized I was on 0.4.1, which wasn't passing `entry` and relying on `relativePath`. And I just saw #13. It looks like bumping to `0.5.0` solves the immediate issue.