### PR TITLE
Allow graphql 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "broccoli-persistent-filter": "^3.1.1",
-    "graphql-tag": "^2.10.0",
+    "graphql-tag": "^2.12.6",
     "object-hash": "^2.0.3"
   },
   "devDependencies": {
@@ -27,7 +27,7 @@
     "mocha": "^5.2.0"
   },
   "peerDependencies": {
-    "graphql": "^14 || ^15"
+    "graphql": "^14 || ^15 || ^16"
   },
   "scripts": {
     "test": "mocha test.js"

--- a/yarn.lock
+++ b/yarn.lock
@@ -717,10 +717,12 @@ graceful-fs@^4.1.6, graceful-fs@^4.2.0:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
-graphql-tag@^2.10.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.0.tgz#87da024be863e357551b2b8700e496ee2d4353ae"
-  integrity sha512-9FD6cw976TLLf9WYIUPCaaTpniawIjHWZSwIRZSjrfufJamcXbVVYfN2TWvJYbw0Xf2JjYbl1/f2+wDnBVw3/w==
+graphql-tag@^2.12.6:
+  version "2.12.6"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.6.tgz#d441a569c1d2537ef10ca3d1633b48725329b5f1"
+  integrity sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==
+  dependencies:
+    tslib "^2.1.0"
 
 graphql@^14.0.2:
   version "14.0.2"
@@ -1738,6 +1740,11 @@ tree-sync@^1.2.2:
     mkdirp "^0.5.1"
     quick-temp "^0.1.5"
     walk-sync "^0.3.3"
+
+tslib@^2.1.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 uglify-js@^3.1.4:
   version "3.4.9"


### PR DESCRIPTION
Also bump graphql-tag to 2.12.6, as that allows that as well (see: https://github.com/apollographql/graphql-tag/blob/main/CHANGELOG.md#v2126)

I guess this might supersede https://github.com/dfreeman/broccoli-graphql-filter/pull/22